### PR TITLE
Add appropriate alt text to main logo

### DIFF
--- a/components/logo.tsx
+++ b/components/logo.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 
 const logo = () => {
     return <div className="logo">
-        <img className="inline w-450 sm:hidden md:inline mb-10 -mt-12" src="/images/mws-logo-new-flat.svg" alt="logo" />
-        <img className="inline w-full sm:inline md:hidden" src="/images/logo-mobile.svg" alt="logo" />
+        <img className="inline w-450 sm:hidden md:inline mb-10 -mt-12" src="/images/mws-logo-new-flat.svg" alt="Modern Web Conf, online & worldwide, March 22-26, 2020" />
+        <img className="inline w-full sm:inline md:hidden" src="/images/logo-mobile.svg" alt="Modern Web Conf, online & worldwide, March 22-26, 2020" />
     </div>
 }
 


### PR DESCRIPTION
This updates the alt attribute to describe the image content. The dates of the conference are not present anywhere on the page as text. Currently anybody listening to this page with a screen reader will not know what the dates of the conference are.