### PR TITLE
Convert clickable image to input

### DIFF
--- a/container/home/index.tsx
+++ b/container/home/index.tsx
@@ -43,8 +43,8 @@ const Home = () => {
     <div className='h-full'>
       <div className='flex items-center justify-between w-full absolute md:-mt-10 pt-1'>
         <div onClick={() => menuOpen()}>
-          <img className="sm:hidden md:inline p-2 ml-2 mt-1 cursor-pointer" src="/images/menu.svg" alt="logo" />
-          <img className="md:hidden sm:inline p-2 ml-2 mt-1 cursor-pointer" src="/images/menu-white.svg" alt="logo" />
+          <input type="image" className="sm:hidden md:inline p-2 ml-2 mt-1 cursor-pointer" src="/images/menu.svg" alt="menu">
+          <input type="image" className="md:hidden sm:inline p-2 ml-2 mt-1 cursor-pointer" src="/images/menu-white.svg" alt="menu">
         </div>
         {showMenu && <NavMenu menuOpen={menuOpen} />}
         <div className="items-center mr-10 sm:hidden md:flex">

--- a/container/home/index.tsx
+++ b/container/home/index.tsx
@@ -43,8 +43,8 @@ const Home = () => {
     <div className='h-full'>
       <div className='flex items-center justify-between w-full absolute md:-mt-10 pt-1'>
         <div onClick={() => menuOpen()}>
-          <input type="image" className="sm:hidden md:inline p-2 ml-2 mt-1 cursor-pointer" src="/images/menu.svg" alt="menu">
-          <input type="image" className="md:hidden sm:inline p-2 ml-2 mt-1 cursor-pointer" src="/images/menu-white.svg" alt="menu">
+          <input type="image" className="sm:hidden md:inline p-2 ml-2 mt-1 cursor-pointer" src="/images/menu.svg" alt="menu" />
+          <input type="image" className="md:hidden sm:inline p-2 ml-2 mt-1 cursor-pointer" src="/images/menu-white.svg" alt="menu" />
         </div>
         {showMenu && <NavMenu menuOpen={menuOpen} />}
         <div className="items-center mr-10 sm:hidden md:flex">


### PR DESCRIPTION
Currently the way for somebody to open the main menu on this site is a click handler attached to an image. In order for a keyboard user to open the menu, that image should be a button. This PR changes the image to an input with type of "image" which will render a button that is keyboard-focusable and has the default visible browser focus style when it is focused. This means that somebody with a disability who needs to use the keyboard to get around the page, can now open the menu.