### PR TITLE
Improve keyboard accessibility in the Nav Menu

### DIFF
--- a/components/navMenu.tsx
+++ b/components/navMenu.tsx
@@ -1,24 +1,59 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 import Link from 'next/link'
-import { buttonList } from '../utility/constants'
+import { buttonList, focusableModalElementTypes } from '../utility/constants'
+
+// the approach to keyboard events and focus trapping in the modal is modified 
+// from this: https://tinloof.com/blog/how-to-create-an-accessible-react-modal/
 
 const NavMenu = (props: any) => {
   const { menuOpen } = props
-  const buttonClass = "menu-btn border-2 mb-5 p-6 border-gray-400 text-xl font-extrabold uppercase text-gray-400 hover:bg-gray-400 focus:outline-none hover:text-white"
+  const buttonClass = "menu-btn border-2 mb-5 p-6 border-gray-400 text-center text-xl font-extrabold uppercase text-gray-400 hover:bg-gray-400 hover:text-white"
   const linkClass = "text-1-2 text-gray-300 font-medium hover:text-blue-100"
   const textClass = 'text-1-2 text-gray-300 font-medium'
+  const modalRef = useRef(null);
+
+  const handleTabKey = e => {
+    const focusableModalElements = modalRef.current.querySelectorAll(focusableModalElementTypes);
+    const firstElement = focusableModalElements[0];
+    const lastElement =
+      focusableModalElements[focusableModalElements.length - 1];
+    if (!e.shiftKey && document.activeElement === lastElement) {
+      firstElement.focus();
+      return e.preventDefault();
+    }
+    if (e.shiftKey && document.activeElement === firstElement) {
+      lastElement.focus();
+      e.preventDefault();
+    }
+  };
+
+  // 27 is Escape key, if pressed, toggle the modal closed
+  const keyListenersMap = new Map([[27, menuOpen], [9, handleTabKey]]);
   useEffect(() => {
     document.body.classList.add('overflow-hidden');
     return () => {
       document.body.classList.remove('overflow-hidden');
     }
   }, [])
+  useEffect(() => {
+    // when the modal is open move keyboard focus inside
+    modalRef.current.focus();
+  }, [modalRef]);
+  useEffect(() => {
+    function keyListener(e) {
+      const listener = keyListenersMap.get(e.keyCode);
+      return listener && listener(e);
+    }
+    document.addEventListener("keydown", keyListener);
+    return () => document.removeEventListener("keydown", keyListener);
+  }, []);
+
 
   return (
-    <div className="bg-white fixed top-0 inset-x-0 z-50 shadow-xs h-screen">
+    <div className="bg-white fixed top-0 inset-x-0 z-50 shadow-xs h-screen" ref={modalRef}>
       <div className="p-3 sm:bg-gray-400 md:bg-white">
-        <img src="/images/close.svg" className="sm:hidden md:inline cursor-pointer" onClick={menuOpen} />
-        <img src="/images/close-white.svg" className="md:hidden sm:inline cursor-pointer" onClick={menuOpen} />
+        <input type="image" alt="close menu" src="/images/close.svg" className="sm:hidden md:inline cursor-pointer" onClick={menuOpen} />
+        <input type="image" alt="close menu" src="/images/close-white.svg" className="md:hidden sm:inline cursor-pointer" onClick={menuOpen} />
       </div>
       <div className="flex sm:flex-wrap md:flex-no-wrap md:w-3/5 sm:w-full mx-auto md:my-10 sm:my-5 sm:pb-40 md:pb-0 overflow-auto max-h-full-100">
         <div className="md:w-2/5 sm:w-full sm:mx-5 md:mx-0">
@@ -40,20 +75,19 @@ const NavMenu = (props: any) => {
         <div className="md:w-1/2 sm:w-full flex flex-col mx-5 sm:order-first md:order-none">
           {buttonList.map(b => <>
             <Link href={`/${b.pageName !== '' ? `#${b.pageName}` : ''}`}>
-              <button
+              <a
                 onClick={() => menuOpen()}
                 className={buttonClass}
-                type="button" >
+                >
                 {b.label}
-              </button>
+              </a>
             </Link>
           </>)}
           <Link href="/code-of-conduct">
-            <button
-              className={buttonClass}
-              type="button" >
+            <a
+              className={buttonClass}>
               code of conduct
-            </button>
+            </a>
           </Link>
           <button
             disabled={true}

--- a/components/navMenu.tsx
+++ b/components/navMenu.tsx
@@ -28,7 +28,7 @@ const NavMenu = (props: any) => {
   };
 
   // 27 is Escape key, if pressed, toggle the modal closed
-  const keyListenersMap = new Map([[27, menuOpen], [9, handleTabKey]]);
+  const keyListeners = {27: menuOpen, 9: handleTabKey};
   useEffect(() => {
     document.body.classList.add('overflow-hidden');
     return () => {
@@ -41,7 +41,7 @@ const NavMenu = (props: any) => {
   }, [modalRef]);
   useEffect(() => {
     function keyListener(e) {
-      const listener = keyListenersMap.get(e.keyCode);
+      const listener = keyListeners[e.keyCode];
       return listener && listener(e);
     }
     document.addEventListener("keydown", keyListener);

--- a/components/navMenu.tsx
+++ b/components/navMenu.tsx
@@ -11,6 +11,7 @@ const NavMenu = (props: any) => {
   const linkClass = "text-1-2 text-gray-300 font-medium hover:text-blue-100"
   const textClass = 'text-1-2 text-gray-300 font-medium'
   const modalRef = useRef(null);
+  const startFocus = useRef(null);
 
   const handleTabKey = e => {
     const focusableModalElements = modalRef.current.querySelectorAll(focusableModalElementTypes);
@@ -36,9 +37,9 @@ const NavMenu = (props: any) => {
     }
   }, [])
   useEffect(() => {
-    // when the modal is open move keyboard focus inside
-    modalRef.current.focus();
-  }, [modalRef]);
+    // when the modal is open, move keyboard focus to the first interactive menu item.
+    startFocus.current.focus();
+  }, [startFocus]);
   useEffect(() => {
     function keyListener(e) {
       const listener = keyListeners[e.keyCode];
@@ -55,7 +56,7 @@ const NavMenu = (props: any) => {
         <input type="image" alt="close menu" src="/images/close.svg" className="sm:hidden md:inline cursor-pointer" onClick={menuOpen} />
         <input type="image" alt="close menu" src="/images/close-white.svg" className="md:hidden sm:inline cursor-pointer" onClick={menuOpen} />
       </div>
-      <div className="flex sm:flex-wrap md:flex-no-wrap md:w-3/5 sm:w-full mx-auto md:my-10 sm:my-5 sm:pb-40 md:pb-0 overflow-auto max-h-full-100">
+      <div role="dialog" aria-label="navigation menu" aria-modal="true" className="flex sm:flex-wrap md:flex-no-wrap md:w-3/5 sm:w-full mx-auto md:my-10 sm:my-5 sm:pb-40 md:pb-0 overflow-auto max-h-full-100">
         <div className="md:w-2/5 sm:w-full sm:mx-5 md:mx-0">
           {/* <p><Link href="/term-service"><a className={linkClass} >Terms of Service</a></Link> </p> */}
           {/* <p><Link href="/privacy-policy"><a className={linkClass} >Privacy Policy</a></Link></p> */}
@@ -73,9 +74,10 @@ const NavMenu = (props: any) => {
           <p className={textClass}>Schedule - coming soon</p>
         </div>
         <div className="md:w-1/2 sm:w-full flex flex-col mx-5 sm:order-first md:order-none">
-          {buttonList.map(b => <>
+          {buttonList.map((b, i) => <>
             <Link href={`/${b.pageName !== '' ? `#${b.pageName}` : ''}`}>
               <a
+                ref={ i ? null : startFocus}
                 onClick={() => menuOpen()}
                 className={buttonClass}
                 >

--- a/utility/constants.ts
+++ b/utility/constants.ts
@@ -290,3 +290,7 @@ export const buttonList = [
     pageName: 'curators'
   }
 ]
+
+
+export const focusableModalElementTypes =
+ 'a[href], button, textarea, input[type="text"], input[type="radio"], input[type="checkbox"], input[type="image"], select'


### PR DESCRIPTION
This PR is a suggestion for solving some of the keyboard navigation issues. If #11 is merged, keyboard users will be able to open the nav menu, but they will still struggle to navigate, because the links are rendered as buttons with no visible focus style, and keyboard focus is not confined to the modal.

This PR does the following:

1. Restores the default focus style on the interactive elements so people can see what is focused.
1. Changes "close" images to inputs and adds alt text so people can close the menu via keyboard.
1. Changes buttons to links (except where buttons are used for disabled state cause they will go away later I'm sure) - a benefit of this is that menu items can now be opened in a new tab, links can be copied with right click, etc.
1. Handles keyboard focus. When the modal opens, focus moves to the Home link in the modal, and is trapped there until the modal closes, so the user can cycle through the modal options without ending up focused on random elements outside the modal.
1. Allows the modal to be closed with the Escape key (this is expected keyboard interaction with modals).
1. Adds aria roles for the div that represents the dialog so that a screenreader knows what is going on, eg, VoiceOver provides this info:
<img width="697" alt="VoiceOver readout that says 'You are currently on a link, inside of a web dialog', followed by instructions for interacting" src="https://user-images.githubusercontent.com/8340719/101288322-f3996980-37c3-11eb-965a-07b5ae67881e.png">

Some of the work is based on the CodePens in this article: https://tinloof.com/blog/how-to-create-an-accessible-react-modal/ with some tweaks, and cross checked with https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal
