### PR TITLE
Remove non-descriptive alt text in profile cards

### DIFF
--- a/components/profileCard.tsx
+++ b/components/profileCard.tsx
@@ -6,7 +6,7 @@ const ProfileCard = (props: ProfileCardProps) => {
   const content = isLast ?
     <>
       <div className="bg-gray-500" >
-        <img src="/images/silhouette.svg" alt="image" className={`w-full ${imageClass}`} />
+        <img src="/images/silhouette.svg" alt="" className={`w-full ${imageClass}`} />
       </div>
       {!isForDescription ? <div className="h-32 flex items-center justify-center cursor-pointer bg-lightGreen-200 hover:bg-lightGreen-100">
         <p className="text-lg text-black font-bold tracking-wide uppercase">See all speakers {'>'}</p>
@@ -19,7 +19,7 @@ const ProfileCard = (props: ProfileCardProps) => {
     </>
     :
     <>
-      <img src={imageUrl} alt="image" className={`w-full ${imageClass}`} />
+      <img src={imageUrl} alt="" className={`w-full ${imageClass}`} />
       <div className="bg-gray-400 p-5">
         <h5 className="text-white uppercase text-1-2">{name}</h5>
         <p className="capitalize text-white opacity-75 text-sm mb-2">{designation}</p>


### PR DESCRIPTION
It's better to have an empty alt attribute in this case, so the image is not announced by screen readers, since the very next text to be read out is the speaker's name. Having the alt text be the word "image" will cause a screen reader to read out something like "Image of image" for every card, which would be tedious and add no information for the user.