### PR TITLE
Add HTML lang attribute via custom Document

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,17 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document'
+
+class MyDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}
+
+export default MyDocument


### PR DESCRIPTION
This will mean that screen readers will know to announce the contents of the page in English, even if the default language of that screen reader is another language.

Added custom _document.tsx file as that seems to be the correct way to tell get Next to modify the HTML element https://nextjs.org/docs/advanced-features/custom-document