### PR TITLE
Improve Sticky header accessibility

### DIFF
--- a/components/stickyHeader.tsx
+++ b/components/stickyHeader.tsx
@@ -2,20 +2,18 @@ import React from 'react';
 import Link from 'next/link'
 
 const StickyHeader = (props) => {
-  return <div className={`flex items-center justify-between fixed top-0 bg-black w-full py-2 px-4 z-40`}>
+  return <nav className={`flex items-center justify-between fixed top-0 bg-black w-full py-2 px-4 z-40`}>
     <div>
-      <img onClick={() => props.menuOpen()} className="inline cursor-pointer" src="/images/menu-white.svg" alt="logo" />
-      <Link href="/"><img className="inline cursor-pointer sm:h-8 md:h-10 sm:ml-5 md:ml-10" src="/images/mws-logo.svg" alt="logo" /></Link>
+      <input type="image" onClick={() => props.menuOpen()} className="inline cursor-pointer" src="/images/menu-white.svg" alt="menu" />
+      <Link href="/"><a><img className="inline cursor-pointer sm:h-8 md:h-10 sm:ml-5 md:ml-10" src="/images/mws-logo.svg" alt="home" /></a></Link>
     </div>
-    <button
-      className="text-black py-1 px-4 md:mr-10 transition-all duration-200 uppercase border-2 border-lightGreen-200 rounded-md text-1-2 font-extrabold bg-lightGreen-200 hover:text-lightGreen-200 hover:bg-black focus:outline-none"
-      type="button" onClick={() => 
-        (document.location.href =
-          'https://ti.to/eventloophq/modern-web-conference')
-      }>
-      get tickets
-    </button>
-  </div>
+    <a
+      className="text-black py-1 px-4 md:mr-10 transition-all duration-200 uppercase border-2 border-lightGreen-200 rounded-md text-1-2 font-extrabold bg-lightGreen-200 hover:text-lightGreen-200 hover:bg-black"
+      type="button"  href="https://ti.to/eventloophq/modern-web-conference"
+      >
+      get tickets 
+    </a>
+  </nav>
 }
 
 export default StickyHeader

--- a/components/stickyHeader.tsx
+++ b/components/stickyHeader.tsx
@@ -9,7 +9,7 @@ const StickyHeader = (props) => {
     </div>
     <a
       className="text-black py-1 px-4 md:mr-10 transition-all duration-200 uppercase border-2 border-lightGreen-200 rounded-md text-1-2 font-extrabold bg-lightGreen-200 hover:text-lightGreen-200 hover:bg-black"
-      type="button"  href="https://ti.to/eventloophq/modern-web-conference"
+      href="https://ti.to/eventloophq/modern-web-conference"
       >
       get tickets 
     </a>


### PR DESCRIPTION
This PR:

1. Turns a clickable image into a button for the menu, so the navigation can be opened by keyboard users
1. Adds an `a` tag inside the Next link for the logo so that it renders an actual link.
1. Updates alt text on the logo link to say "home" as that's the best label I could think of for this link to "/"
1. Turns the "get tickets" button with JS location.href-replacement into a regular link, so users know what will happen when it is clicked
1. Restores browser default focus style for that button so users know when it has keyboard focus
1. Change the outermost element to `nav` since this is all navigation stuff.