### PR TITLE
Add accessibility to speaker filter controls

### DIFF
--- a/components/speakerFilter.tsx
+++ b/components/speakerFilter.tsx
@@ -22,14 +22,18 @@ const SpeakerFilter = (props: SpeakerFilterProps) => {
 
 const FilterItem = (props: FilterItemProps) => {
   const { image, title, selected, onClick } = props
+  const id = title.replace(/\s+/g, '')
   return (
-    <div
-      className={`sm:flex-70 lg:flex-auto whitespace-no-wrap sm:mr-3 lg:mr-0 lg:mb-3 lg:w-full flex p-3 rounded cursor-pointer ${selected ? 'bg-black' : 'bg-gray-600 hover:bg-gray-700'}`}
-      onClick={onClick}
-    >
-      <img src={image} className="h-5 mr-3" />
-      <p className="pr-2 text-1-2 text-white uppercase sm:font-medium lg:font-extrabold leading-5 ">{title}</p>
-    </div>
+    <>
+      <input type="checkbox" id={id} className="sr-only speaker-filter-checkbox" checked={selected} onChange={onClick}/>
+      <label
+        htmlFor={id}      
+        className={`sm:flex-70 lg:flex-auto whitespace-no-wrap sm:mr-3 lg:mr-0 lg:mb-3 lg:w-full flex p-3 rounded cursor-pointer ${selected ? 'bg-black' : 'bg-gray-600 hover:bg-gray-700'}`}
+      >
+        <img src={image} className="h-5 mr-3" alt="" />
+        <p className="pr-2 text-1-2 text-white uppercase sm:font-medium lg:font-extrabold leading-5 ">{title}</p>
+      </label>
+    </>
   )
 }
 

--- a/container/speaker/index.tsx
+++ b/container/speaker/index.tsx
@@ -217,7 +217,7 @@ const Speaker = (props: any) => {
             <SpeakerFilter
               onClick={handleFilterClick}
               filterList={filters}
-            />            
+            />
             <div className="text-center">
               <p className="ml-5 uppercase text-xs text-gray-400 font-extrabold">Interested in speaking?</p>
               <a href="https://docs.google.com/forms/d/e/1FAIpQLSd2mAqQAEs1K8HpTs41XcX7u8CpPx975gJ2VJCjE3bjNb-vzQ/viewform">
@@ -227,7 +227,6 @@ const Speaker = (props: any) => {
           </div>
         </div>
         <p className="uppercase lg:absolute lg:bottom-0 lg:mb-5 sm:mt-5 lg:mt-0 sm:mx-auto text-xl text-gray-400 font-semibold">more speakers to be announced soon!</p>
-        
         <div className="sm:block lg:hidden p-4 mb-16 w-full">
           {/* <button type="button" className="w-full uppercase border-purple-100 rounded-md text-purple-100 font-black border-2 p-4 text-lg mt-1 focus:outline-none">see all speakers</button> */}
           <p className="text-center uppercase text-xs text-gray-400 font-extrabold">Interested in speaking?</p>

--- a/container/speaker/index.tsx
+++ b/container/speaker/index.tsx
@@ -105,7 +105,6 @@ const Speaker = (props: any) => {
           <p className="text-gray-300 font-medium text-1-2 lg:w-5/6 sm:w-full ">{"Whether you’re interested in learning a new technology or advancing your skills in a familiar stack, there’s something for everyone at the Modern Web Conf."}</p>
         </div>
       </div>
-
       <div className="relative flex sm:flex-wrap lg:flex-no-wrap lg:pl-40 md:p-10 sm:p-0">
         <div className="sticky top-56 sm:block lg:hidden w-full z-50 bg-white pl-4 py-1">
           <SpeakerFilter
@@ -214,10 +213,11 @@ const Speaker = (props: any) => {
         <div className="flex-col mb-2 sm:w-full lg:w-1/5 lg:mt-32 sm:hidden lg:flex">
           <div className="sticky top-100">
             <p className="uppercase text-1-2 text-center font-extrabold sm:hidden lg:block">refine by track</p>
+            <p aria-live="polite" className="sr-only">Speakers Displayed: {speakerFilteredList.length}</p>
             <SpeakerFilter
               onClick={handleFilterClick}
               filterList={filters}
-            />
+            />            
             <div className="text-center">
               <p className="ml-5 uppercase text-xs text-gray-400 font-extrabold">Interested in speaking?</p>
               <a href="https://docs.google.com/forms/d/e/1FAIpQLSd2mAqQAEs1K8HpTs41XcX7u8CpPx975gJ2VJCjE3bjNb-vzQ/viewform">
@@ -227,6 +227,7 @@ const Speaker = (props: any) => {
           </div>
         </div>
         <p className="uppercase lg:absolute lg:bottom-0 lg:mb-5 sm:mt-5 lg:mt-0 sm:mx-auto text-xl text-gray-400 font-semibold">more speakers to be announced soon!</p>
+        
         <div className="sm:block lg:hidden p-4 mb-16 w-full">
           {/* <button type="button" className="w-full uppercase border-purple-100 rounded-md text-purple-100 font-black border-2 p-4 text-lg mt-1 focus:outline-none">see all speakers</button> */}
           <p className="text-center uppercase text-xs text-gray-400 font-extrabold">Interested in speaking?</p>

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -217,3 +217,9 @@ body {
         @apply p-6;
     }
 }
+
+.speaker-filter-checkbox:focus + label {
+    outline: 5px auto Highlight;
+    outline: 5px auto -webkit-focus-ring-color;
+    background-color: #343434;
+}


### PR DESCRIPTION
Currently, the speaker list can be filtered by clicking on filters on the right hand side of the screen. Those filters are divs with click handlers, which are not accessible because only sighted mouse/touchscreen users will be able to know that they are interactive or be able to click on them.

Since more than one of these divs can be active at a time, allowing the filter to include multiple chosen categories, I think theses divs really represent a checkbox interaction. So in this PR I'm suggesting the following:

1. Minor HTML updates to get these rendering as checkboxes (using Tailwind's `sr-only` class to avoid changing the visible layout)
1. Add a keyboard focus style to those elements, which is the existing hover style plus default browser focusring.
1. Fix missing alt attr.
1. Add a screen-reader only aria live region which will announce the updated total when the speaker list updates due to interacting with the filter. This is based on some considerations discussed here: https://technology.blog.gov.uk/2014/08/14/improving-accessibility-on-gov-uk-search/.
