### PR TITLE
Add heading structure, title, & some alt text

### DIFF
--- a/components/aboutDescription.tsx
+++ b/components/aboutDescription.tsx
@@ -14,8 +14,8 @@ const AboutDescription = (props: any) => {
 
   return (
     <div className={parentClass}>
-      <img src={image} />
-      <p className="text-2xl uppercase text-black font-extrabold mb-2" >{title}</p>
+      <img src={image} alt="" />
+      <h4 className="text-2xl uppercase text-black font-extrabold mb-2" >{title}</h4>
       <AnimationWrapper effect={'fadein'} parentClass="">
         <p className="text-gray-300 font-medium text-1-2 sm:w-full mb-8">{firstDescription}</p>
         {secondDescription && <p className="text-gray-300 font-medium text-1-2 sm:w-full mb-8">{secondDescription}</p>}

--- a/components/profileCard.tsx
+++ b/components/profileCard.tsx
@@ -11,7 +11,7 @@ const ProfileCard = (props: ProfileCardProps) => {
       {!isForDescription ? <div className="h-32 flex items-center justify-center cursor-pointer bg-lightGreen-200 hover:bg-lightGreen-100">
         <p className="text-lg text-black font-bold tracking-wide uppercase">See all speakers {'>'}</p>
       </div> : <div className="bg-gray-400 p-5">
-          <h5 className="text-white uppercase text-1-2">{name}</h5>
+          <h3 className="text-white uppercase text-1-2">{name}</h3>
           <p className="capitalize text-white opacity-75 text-sm mb-2">{designation}</p>
           {companyName !== '' && <p className="text-white opacity-75 text-sm flex items-baseline"><img className="inline mr-2 h-3" src="/images/office.svg" alt="office" /> <span>{companyName}</span></p>}
           <p className="text-white opacity-75 text-sm flex items-baseline"><img className="inline mr-2 h-3" src="/images/map-pin.svg" alt="address" /> <span>{locationFull}</span></p>
@@ -21,7 +21,7 @@ const ProfileCard = (props: ProfileCardProps) => {
     <>
       <img src={imageUrl} alt="image" className={`w-full ${imageClass}`} />
       <div className="bg-gray-400 p-5">
-        <h5 className="text-white uppercase text-1-2">{name}</h5>
+        <h4 className="text-white uppercase text-1-2">{name}</h4>
         <p className="capitalize text-white opacity-75 text-sm mb-2">{designation}</p>
         {companyName !== '' && <p className="text-white opacity-75 text-sm flex items-baseline"><img className="inline mr-2 h-3" src="/images/office.svg" alt="office" /> <span>{companyName}</span></p>}
         <p className="text-white opacity-75 text-sm flex items-baseline"><img className="inline mr-2 h-3" src="/images/map-pin.svg" alt="address" /> <span>{locationFull}</span></p>

--- a/components/title.tsx
+++ b/components/title.tsx
@@ -4,7 +4,7 @@ const Title = (props: TitleProps) => {
   const { title, parentClass } = props
   return (
     <div className={`relative my-3 ${parentClass}`}>
-      <p className="uppercase text-base text-white border-white border-2 bg-gray-400 absolute bottom-1/2 transform translate-y-1/2 px-4 py-1">{title}</p>
+      <h4 className="uppercase text-base text-white border-white border-2 bg-gray-400 absolute bottom-1/2 transform translate-y-1/2 px-4 py-1">{title}</h4>
     </div>
   )
 }

--- a/container/about/index.tsx
+++ b/container/about/index.tsx
@@ -17,25 +17,25 @@ const About = (props: VisibleProps) => {
     <div className={`bg-white shadow-xs opacity-0  ${className} sm:pb-16 `}>
       <div className="flex sm:flex-wrap lg:flex-no-wrap">
         <div className="bg-black lg:w-23 sm:w-full sm:flex-none lg:flex-23 h-32 flex items-end self-start justify-center">
-          <h4 className="text-5xl text-white leading-7 uppercase">About</h4>
+          <h2 className="text-5xl text-white leading-7 uppercase">About</h2>
         </div>
         <div className="flex flex-col p-6 sm:text-center lg:text-left lg:pt-24">
-          <h5 className="text-2xl font-extrabold uppercase" >{"the modern web is constantly evolving"}</h5>
+          <h3 className="text-2xl font-extrabold uppercase" >{"the modern web is constantly evolving"}</h3>
           <p className="text-gray-300 font-medium text-1-2 md:w-full sm:w-full">{"Each one of us have contributed to the modern web in our own way. We discover technologies that solve our problems (and perhaps inspire us), join a community, and get to work. We share our experience with our coworkers, colleagues, and online network. But there is much more to the web community than our own little islands."}</p>
           <p className="text-gray-300 font-medium text-1-2 md:w-full sm:w-full pt-8">{"The Modern Web Conf not only to provides you with in-depth knowledge about the technologies you’re currently working with, but also exposes you to new ways of thinking and approaches from adjacent communities. You’ll learn from thought-leaders in your community and beyond, and connect with like-minded individuals with unique, thought-provoking perspectives. "}</p>
         </div>
       </div>
       <div className="flex flex-wrap lg:mt-6 lg:px-24">
         <AnimationWrapper parentClass="md:w-3/5 sm:w-full md:p-10 sm:p-5">
-          <p className="text-2xl uppercase text-black font-extrabold">More than just a livestream</p>
+          <h3 className="text-2xl uppercase text-black font-extrabold">More than just a livestream</h3>
           <p className="text-gray-300 font-medium text-1-2 sm:w-full pt-4">{"Let’s face it: a livestream of talks is not a real conference. There is so much more to a conference than the presentations, and the online events we’ve seen in 2020 simply don’t achieve a true conference experience."}</p>
           <p className="text-gray-300 font-medium text-1-2 sm:w-full pt-8">{"The Modern Web Conf is different. It takes place on a new, revolutionary events platform called EventLoop -- a web app that’s purpose-built for online meetups and conferences. It provides attendees, speakers, and sponsors alike with an all-encompassing experience that inspires and facilitates true connections between people.  "}</p>
         </AnimationWrapper>
         <AnimationWrapper parentClass="md:w-2/5 sm:w-full sm:p-5 md:pt-24">
-          <img src="/images/mws_plus_eventloop.svg" />
+          <img src="/images/mws_plus_eventloop.svg" alt="" />
         </AnimationWrapper>
         <div className="md:p-10 w-full">
-          <p className="text-2xl uppercase text-black font-extrabold sm:text-center md:text-left">What you’ll experience</p>
+          <h3 className="text-2xl uppercase text-black font-extrabold sm:text-center md:text-left">What you’ll experience</h3>
         </div>
         <AnimationWrapper parentClass="md:w-1/2 sm:w-full md:p-10 md:pt-0 sm:p-5">
           <AboutDescription

--- a/container/codeOfConduct/codeOfConduct.tsx
+++ b/container/codeOfConduct/codeOfConduct.tsx
@@ -10,10 +10,10 @@ const CodeOfConduct = () => <>
     <div className={`bg-white shadow-xs`}>
       <div className="flex sm:flex-wrap lg:flex-no-wrap">
         <div className="bg-black lg:w-23 sm:w-full sm:flex-none lg:flex-23 h-32 flex items-end self-start justify-center">
-          <h4 className="text-5xl text-white leading-7 uppercase">Code Of Conduct</h4>
+          <h2 className="text-5xl text-white leading-7 uppercase">Code Of Conduct</h2>
         </div>
         <div className="flex flex-col p-6 lg:pt-20">
-          <h5 className="text-2xl font-extrabold uppercase lg:w-3/4" >{"We take conduct at the Modern Web Conf very seriously. please take the time to read it!"}</h5>
+          <h3 className="text-2xl font-extrabold uppercase lg:w-3/4" >{"We take conduct at the Modern Web Conf very seriously. please take the time to read it!"}</h3>
           {CodeOfConductList.map((p,i) =>
             <React.Fragment key={i}>
               {p.point && <p className={'text-gray-300 font-extrabold text-1-2 lg:w-3/4'}>{p.point}</p>}

--- a/container/curators/index.tsx
+++ b/container/curators/index.tsx
@@ -20,10 +20,10 @@ const Curators = (props: any) => {
     <div className={`bg-white shadow-xs opacity-0  ${className} lg:pb-10 `}>
       <div className="flex sm:flex-wrap lg:flex-no-wrap">
         <div className="bg-black lg:w-23 sm:w-full sm:flex-none lg:flex-23 h-32 flex items-end self-start justify-center">
-          <h4 className="text-5xl text-white leading-7 uppercase">Curators</h4>
+          <h2 className="text-5xl text-white leading-7 uppercase">Curators</h2>
         </div>
         <div className="flex flex-col p-6 sm:text-center lg:text-left lg:pt-24">
-          <h5 className="text-2xl font-extrabold uppercase" >{"expert talk selection"}</h5>
+          <h3 className="text-2xl font-extrabold uppercase" >{"expert talk selection"}</h3>
           <p className="text-gray-300 font-medium text-1-2 lg:w-4/6 sm:w-full">{"We’ve assembled a team of experts well-known for their knowledge in and contributions to their industry & specialization. Track curators also work together to select the general session keynotes!"}</p>
         </div>
       </div>

--- a/container/finances/index.tsx
+++ b/container/finances/index.tsx
@@ -18,10 +18,10 @@ const Finances = (props: VisibleProps) => {
     <div className={`bg-white shadow-xs opacity-0  ${className} sm:pb-16 lg:pb-8 `}>
       <div className="flex sm:flex-wrap lg:flex-no-wrap">
         <div className="bg-black lg:w-23 sm:w-full sm:flex-none lg:flex-23 h-32 flex items-end self-start justify-center">
-          <h4 className="text-5xl text-white leading-7 uppercase">Finances</h4>
+          <h2 className="text-5xl text-white leading-7 uppercase">Finances</h2>
         </div>
         <div className="flex flex-col p-6 sm:text-center lg:text-left lg:pt-24">
-          <h5 className="text-2xl font-extrabold uppercase" >{"where does the money for this event go? "}</h5>
+          <h3 className="text-2xl font-extrabold uppercase" >{"where does the money for this event go? "}</h3>
           <p className="text-gray-300 font-medium text-1-2 lg:w-4/6 sm:w-full">{"The pricing of this event is intended to be extremely affordable in order to maximize our reach and accessibility. But there are still many expenses and other plans for the income from the event, and we have chosen to be completely upfront about where that money is going! "}</p>
         </div>
       </div>

--- a/container/getInvolved/index.tsx
+++ b/container/getInvolved/index.tsx
@@ -47,10 +47,10 @@ const GetInvolved = (props: VisibleProps) => {
     <div className={`bg-white shadow-xs opacity-0  ${className}`}>
       <div className="flex sm:flex-wrap lg:flex-no-wrap">
         <div className="bg-black lg:w-23 sm:w-full sm:flex-none lg:flex-23 h-32 flex items-end self-start justify-center">
-          <h4 className="text-5xl text-white leading-7 uppercase">GET INVOLVED</h4>
+          <h2 className="text-5xl text-white leading-7 uppercase">GET INVOLVED</h2>
         </div>
         <div className="flex flex-col p-6 sm:text-center lg:text-left lg:pt-24">
-          <h5 className="text-2xl font-extrabold uppercase" >{"Want to get more involved?"}</h5>
+          <h3 className="text-2xl font-extrabold uppercase" >{"Want to get more involved?"}</h3>
           <p className="text-gray-300 font-medium text-1-2 lg:w-3/4 sm:w-full">
             {"We’re looking for committed people who are excited about community events, networking, and love geeking out on web dev and design!"}</p>
         </div>

--- a/container/home/index.tsx
+++ b/container/home/index.tsx
@@ -68,6 +68,7 @@ const Home = () => {
           <img className="inline self-start -ml-5 animated fadeInDownBig slow" src="/images/left-bar-2.svg" alt="logo" />
           <img className="inline self-start -ml-5 animated fadeInDownBig slower" src="/images/left-bar-3.svg" alt="logo" />
         </div>
+        <h1 className="sr-only">Modern Web Conf - March 22-26, 2021</h1>
         <div className='md:w-2/4 sm:w-full mx-auto text-center md:-mt-10 sm:mt-0 flex flex-col'>
           <Logo />
           <p className='text-gray-300 font-medium text-1-2 md:mb-5 sm:p-5 md:p-0'>

--- a/container/modern/index.tsx
+++ b/container/modern/index.tsx
@@ -41,7 +41,7 @@ const Modern = (props) => {
           git pull
         </Typist>}
       </div>
-      {dataVisible && <h5 className="text-lightGreen-200 sm:text-xl md:text-4xl font-menlo animated delay-75s fadeIn">WEB COMMUNITIES TOGETHER</h5>}
+      {dataVisible && <p className="text-lightGreen-200 sm:text-xl md:text-4xl font-menlo animated delay-75s fadeIn">WEB COMMUNITIES TOGETHER</p>}
       <div className="flex justify-center mb-2 mt-10">
         {dataVisible && <p className="text-white sm:text-1-2 md:text-xl font-menlo mr-3 animated delay-1s fadeIn ">modern_web_conf$  </p>}
         {typistVisible2 && <Typist
@@ -52,7 +52,7 @@ const Modern = (props) => {
           git push
         </Typist>}
       </div>
-      {dataVisible && <h5 className="text-lightGreen-200 sm:text-xl md:text-4xl font-menlo animated delay-3s fadeIn">THE BOUNDS OF POSSIBILITY</h5>}
+      {dataVisible && <p className="text-lightGreen-200 sm:text-xl md:text-4xl font-menlo animated delay-3s fadeIn">THE BOUNDS OF POSSIBILITY</p>}
     </div >
   )
 }

--- a/container/privacyPolicy/privacyPolicy.tsx
+++ b/container/privacyPolicy/privacyPolicy.tsx
@@ -10,10 +10,10 @@ const PrivacyPolicy = () => <>
     <div className={`bg-white shadow-xs`}>
       <div className="flex sm:flex-wrap lg:flex-no-wrap">
         <div className="bg-black lg:w-23 sm:w-full sm:flex-none pt-20 lg:flex-23 h-32 flex items-end self-start justify-center">
-          <h4 className="text-5xl text-white leading-7 uppercase">Privacy Policy</h4>
+          <h2 className="text-5xl text-white leading-7 uppercase">Privacy Policy</h2>
         </div>
         <div className="flex flex-col p-6 lg:pt-24">
-          <h5 className="text-2xl font-extrabold uppercase lg:w-3/4" >{"Privacy Policy PlaceHolder"}</h5>
+          <h3 className="text-2xl font-extrabold uppercase lg:w-3/4" >{"Privacy Policy PlaceHolder"}</h3>
           {privacyPolicyList.map((p, i) =>
             <React.Fragment key={i}>
               <p className={'text-gray-300 font-medium text-1-2 lg:w-3/4'}>{p}</p>

--- a/container/speaker/index.tsx
+++ b/container/speaker/index.tsx
@@ -98,10 +98,10 @@ const Speaker = (props: any) => {
     <div className={`bg-white shadow-xs opacity-0 ${className}`}>
       <div className="flex sm:flex-wrap lg:flex-no-wrap">
         <div className="bg-black lg:w-23 sm:w-full sm:flex-none lg:flex-23 h-32 flex items-end self-start justify-center">
-          <h4 className="text-5xl text-white leading-7 uppercase">SPEAKERS</h4>
+          <h2 className="text-5xl text-white leading-7 uppercase">SPEAKERS</h2>
         </div>
         <div className="flex flex-col p-6 sm:text-center lg:text-left lg:pt-24">
-          <h5 className="text-2xl font-extrabold uppercase" >{"5 days, 100+ sessions, workshops, & Discussions"}</h5>
+          <h3 className="text-2xl font-extrabold uppercase" >{"5 days, 100+ sessions, workshops, & Discussions"}</h3>
           <p className="text-gray-300 font-medium text-1-2 lg:w-5/6 sm:w-full ">{"Whether you’re interested in learning a new technology or advancing your skills in a familiar stack, there’s something for everyone at the Modern Web Conf."}</p>
         </div>
       </div>

--- a/container/sponsor/index.tsx
+++ b/container/sponsor/index.tsx
@@ -18,11 +18,11 @@ const Sponsor = (props: VisibleProps) => {
     <div className={`bg-white shadow-xs opacity-0  ${className}`}>
       <div className="flex sm:flex-wrap lg:flex-no-wrap">
         <div className="bg-black lg:w-23 sm:w-full sm:flex-none lg:flex-23 h-32 flex items-end self-start justify-center">
-          <h4 className="text-5xl text-white leading-7 uppercase">SPONSORS</h4>
+          <h2 className="text-5xl text-white leading-7 uppercase">SPONSORS</h2>
         </div>
 
         <div className="flex flex-col px-6 sm:text-center lg:text-left lg:pt-24">
-          <h5 className="text-2xl font-extrabold uppercase" >{"Innovation at its Finest"}</h5>
+          <h3 className="text-2xl font-extrabold uppercase" >{"Innovation at its Finest"}</h3>
           <p className="text-gray-300 font-medium text-1-2 lg:w-3/4 sm:w-full">{"APIs & tools that improve the developer experience. Platforms for streamlined collaborative work. Technologies that empower every member of your organization, and make for a better user experience. Sponsors of the Modern Web Conf are building interesting, sustainable, and forward-thinking ideas and services. In addition to providing financial support of the event, Sponsors have their own track for Expo sessions that dive deep into these ideas. From presentations and panels to breakout discussions & workshops, you can get up close with the companies, products, and tools that most interest you."}</p>
         </div>
       </div>

--- a/container/termService/termService.tsx
+++ b/container/termService/termService.tsx
@@ -10,10 +10,10 @@ const TermService = () => {
         <div className={`bg-white shadow-xs`}>
           <div className="flex sm:flex-wrap lg:flex-no-wrap">
             <div className="bg-black lg:w-23 sm:w-full sm:flex-none lg:flex-23 h-32 flex items-end self-start justify-center">
-              <h4 className="text-2-8 text-white leading-6 uppercase">Terms of service</h4>
+              <h2 className="text-2-8 text-white leading-6 uppercase">Terms of service</h2>
             </div>
             <div className="flex flex-col p-6 lg:pt-24">
-              <h5 className="text-2xl font-extrabold uppercase" >{"Terms of service PlaceHolder"}</h5>
+              <h3 className="text-2xl font-extrabold uppercase" >{"Terms of service PlaceHolder"}</h3>
               {privacyPolicyList.map((p, i) =>
                 <React.Fragment key={i}>
                   <p className={'text-gray-300 font-medium text-1-2 lg:w-3/4 sm:w-full'}>{p}</p>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,6 +12,7 @@ export default function MyApp({ Component, pageProps }) {
   return (
     <>
     <Head>
+      <title>Modern Web Conf</title>
       {Metas.map((m, i) => <React.Fragment key={i}>{m}</React.Fragment>)}
     </Head>
     <ApolloProvider client={client}>


### PR DESCRIPTION
This PR is a suggestion to:

1. Add a title element to the page
1. Add a `<h1>` element and update other headings to nest correctly. There's no visible impact because tailwind preflight css removes any browser heading styles, so this is purely to expose the document hierarchy correctly to a screen reader. A couple of the decisions are pretty marginal - like whether subtitles are really an extra level deep, but it seems on balance that they are.
1. Add empty alt text to some decorative images. With no alt text, what screen reader users here is the filename of the image.