### PR TITLE
Give visible focus style to button links and fix Button markup

### DIFF
--- a/components/button.tsx
+++ b/components/button.tsx
@@ -5,11 +5,11 @@ const Button = (props) => {
     const buttonClass = "animate-btn w-full"
     return (props.link ?
         <Link href={props.link}>
-            <button
+            <a
                 className={buttonClass}
                 type="button" >
                 {props.text}
-            </button>
+            </a>
         </Link> :
         <button
             onClick={() => props.handleButtonClick()}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -23,11 +23,7 @@ body {
     background-size: 200% 100%;
     background-position: right bottom;
 
-    &:focus {
-        @apply outline-none;
-    }
-
-    &:hover {
+    &:hover, &:focus {
         @apply text-lightGreen-200;
         background-position: left bottom;
 


### PR DESCRIPTION
This PR makes some small changes to the Button component. Currently when the `link` prop is passed, the component does attempt to use that as the href in a Next link, but in the end it still renders a button with a JS redirect to the URL. Changing the `<button>` inside of the `<Link>` component to an `<a>` tag instructs Next to render this as an actual link.

The other change is to remove the outline-none focus style, and use the hover style for focus on the buttons.

With these changes, that row of links at the bottom of the page have a visible focus style, and screenreader users will know that they are links, folks can open them in new tabs, etc.